### PR TITLE
Issue #57 and #59

### DIFF
--- a/kardboard/static/style.css
+++ b/kardboard/static/style.css
@@ -361,3 +361,7 @@ table.board p.title a:hover {
 table.leaderboard td {
     width: 25%;
 }
+
+.changelog-entry { margin-bottom: 15px; }
+.changelog-entry h5 { margin-bottom: 5px; margin-top: 0px; } 
+.changelog-entry table { margin-left: 0px; width: 100%; font-size: 0.83em; }

--- a/kardboard/templates/card.html
+++ b/kardboard/templates/card.html
@@ -25,35 +25,36 @@
 {% endmacro %}
 
 
-{% macro card_diff(version, diff) %}
-    <div class="changelog-entry">
-        <h5>
-            {% if version.action == 'CREATE' %}
-                Created by
-            {% elif version.action == 'UPDATE' %}
-                Updated by
-            {% elif version.action == 'DELETE' %}
-                Deleted by
-            {% elif version.action == 'INITIAL' %}
-                Initial by
-            {% endif %}
-            <a href="{{ url_for('person', name=version.updated_by) }}">{{ version.updated_by }}</a> at {{ none_or_date(version.updated_at) }}
-        </h5>
-        <table>
-            <tr>
-                <th>Field</th>
-                <th>Old Value</th>
-                <th>New Value</th>
-            </tr>
-            {% for name, change in diff.items() %}
-            <tr class="{{ loop.cycle('odd', 'even') }}">
-                <td style="width: 20%">{{ name }}</td>
-                <td style="width: 40%">{{ version.field_string(name, change['old']) }}</td>
-                <td style="width: 40%">{{ version.field_string(name, change['new']) }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-    </div>
+{% macro card_diff(version) %}
+    {% if not version.initial_record %}
+        <div class="changelog-entry">
+            <h5>
+                {{ version.action_verb }} by
+                    
+                {% if version.updated_by is none %}
+                    <i>System</i>
+                {% else %}
+                    <a href="{{ url_for('person', name=version.updated_by) }}">{{ version.updated_by }}</a> 
+                {% endif %}
+                at {{ version.updated_at.strftime("%m/%d/%Y %I:%M %p") }}
+            </h5>
+
+            <table>
+                <tr>
+                    <th>Field</th>
+                    <th>Old Value</th>
+                    <th>New Value</th>
+                </tr>
+                {% for name, diff in version.diff.items() %}
+                <tr class="{{ loop.cycle('odd', 'even') }}">
+                    <td style="width: 20%">{{ name|replace('_', ' ')|capitalize }}</td>
+                    <td style="width: 40%">{{ version.value_string(diff['old']) }}</td>
+                    <td style="width: 40%">{{ version.value_string(diff['new']) }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    {% endif %}
 {% endmacro %}
 
 
@@ -150,19 +151,21 @@
         {% endmarkdown2 %}
         {% endautoescape %}
         {% endif %}
+    {% endif %}
 
+    {% set versions = card.get_version_history() %}
+    {# Don't show initial bookkeeping #}
+    {% if versions|count > 0 and not (versions|count == 1 and versions[0].initial_record) %}
         <h4>Changelog</h4>
-        {% for snapshot, diff in card.get_snapshot_diffs() %}
-            {{ card_diff(snapshot, diff) }}
+        {% for version in versions %}
+            {{ card_diff(version) }}
         {% endfor %}
+    {% endif %}
 
-      {% endif %}
-
-      {{ card_controls(request, card) }}
+    {{ card_controls(request, card) }}
 
 
-      </div>
-
+    </div>
 </div>
 
 {% endblock content %}

--- a/kardboard/templates/card.html
+++ b/kardboard/templates/card.html
@@ -24,6 +24,39 @@
       </p>
 {% endmacro %}
 
+
+{% macro card_diff(version, diff) %}
+    <div class="changelog-entry">
+        <h5>
+            {% if version.action == 'CREATE' %}
+                Created by
+            {% elif version.action == 'UPDATE' %}
+                Updated by
+            {% elif version.action == 'DELETE' %}
+                Deleted by
+            {% elif version.action == 'INITIAL' %}
+                Initial by
+            {% endif %}
+            <a href="{{ url_for('person', name=version.updated_by) }}">{{ version.updated_by }}</a> at {{ none_or_date(version.updated_at) }}
+        </h5>
+        <table>
+            <tr>
+                <th>Field</th>
+                <th>Old Value</th>
+                <th>New Value</th>
+            </tr>
+            {% for name, change in diff.items() %}
+            <tr class="{{ loop.cycle('odd', 'even') }}">
+                <td style="width: 20%">{{ name }}</td>
+                <td style="width: 40%">{{ version.field_string(name, change['old']) }}</td>
+                <td style="width: 40%">{{ version.field_string(name, change['new']) }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+{% endmacro %}
+
+
 {% block content %}
 
 <div class="metric card_detail">
@@ -118,6 +151,10 @@
         {% endautoescape %}
         {% endif %}
 
+        <h4>Changelog</h4>
+        {% for snapshot, diff in card.get_snapshot_diffs() %}
+            {{ card_diff(snapshot, diff) }}
+        {% endfor %}
 
       {% endif %}
 

--- a/kardboard/tickethelpers.py
+++ b/kardboard/tickethelpers.py
@@ -79,7 +79,7 @@ class NullHelper(TicketHelper):
         return None
 
     def login(self, username, password):
-        return None
+        return True
 
 
 class TestTicketHelper(TicketHelper):

--- a/kardboard/views.py
+++ b/kardboard/views.py
@@ -195,8 +195,13 @@ def card_edit(key):
     if request.method == "POST":
         f = _init_card_form(request.form)
         if f.validate():
+            # Check if we need an initial version before tracking changes
+            if len(card.version_history) == 0:
+                card.snapshot('INITIAL')
+
             f.populate_obj(card)
             card.save()
+
             flash("Card %s successfully edited" % card.key)
             return True   # Redirect
 

--- a/kardboard/views.py
+++ b/kardboard/views.py
@@ -195,10 +195,6 @@ def card_edit(key):
     if request.method == "POST":
         f = _init_card_form(request.form)
         if f.validate():
-            # Check if we need an initial version before tracking changes
-            if len(card.version_history) == 0:
-                card.snapshot('INITIAL')
-
             f.populate_obj(card)
             card.save()
 


### PR DESCRIPTION
This is a first stab at adding in rudimentary version history for card updates. I've updated templates to show who performed what action and what they did (old/new values). State tracking is customizable via SNAPSHOT_FIELDS in Kard and view is limited to last 3 edits.

Example: http://cl.ly/0a1g0B3v0T0S2E0P0h3d
