### PR TITLE
Added content_detail destination anchors for team card and funnel boards

### DIFF
--- a/kardboard/templates/card.html
+++ b/kardboard/templates/card.html
@@ -44,7 +44,7 @@
 
 {% block content %}
 
-<div class="metric card_detail">
+<div class="metric card_detail" id="content_detail">
       <h2 style="font-weight: bold;">
         {{ card.key }} /
             {% if card.done_date %}

--- a/kardboard/templates/funnel.html
+++ b/kardboard/templates/funnel.html
@@ -44,7 +44,7 @@ $(document).ready(function() {
 </p>
 
 
-<table class="funnel">
+<table class="funnel" id="content_detail">
 <thead>
     <caption>{{ state }}: {{ cards|length }}</caption>
     <tr>

--- a/kardboard/templates/team.html
+++ b/kardboard/templates/team.html
@@ -104,7 +104,7 @@ key        service_class        cycle_time        done_date
 
 
 
-<div class="{% if team_slug %}team_page_board{% else %}overview_board{% endif %}">
+<div class="{% if team_slug %}team_page_board{% else %}overview_board{% endif %}" id="content_detail">
 
 {% if not team_slug %}
     {% set repeat_headers = True %}


### PR DESCRIPTION
Allowing teams, cards, and funnels to go directly to https://server/team|card|funnel/slug/#content_detail to skip the header.
