### PR TITLE
Stop search box from raising 500 when searching empty string.

### DIFF
--- a/kardboard/templates/base.html
+++ b/kardboard/templates/base.html
@@ -57,7 +57,8 @@
 
             <form action="/quick/" method="GET">
                 <label for="search">Search:</label>
-                <input type="text" name="key" id="search" />
+                <input type="text" name="key" id="search" required="required" />
+                <input type="hidden" name="return_path" value="{{ request.path }}" />
                 <input type="submit" value="Go" name="go" />
             </form>
         </div>

--- a/kardboard/views.py
+++ b/kardboard/views.py
@@ -534,8 +534,11 @@ def quick():
     key = request.args.get('key', None)
     key = key.strip()
     if not key:
-        url = url_for('dashboard')
-        return redirect(url)
+        previous = request.args.get('return_path', None)
+        if previous:
+            return redirect(previous)
+        else:
+            return redirect('/')
 
     try:
         card = Kard.objects.get(key=key)


### PR DESCRIPTION
500 Error when searching empty string from search bar in dashboard.

``` bash
10.0.2.2 - - [31/Jul/2014 19:08:00] "GET /quick/?key=&go=Go HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1701, in __call__
    return self.wsgi_app(environ, start_response)
  File "/vagrant/kardboard/util.py", line 387, in __call__
    return self.app(environ, start_response)
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1689, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/vagrant/kardboard/views.py", line 537, in quick
    url = url_for('dashboard')
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/helpers.py", line 361, in url_for
    return appctx.app.handle_url_build_error(error, endpoint, values)
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/flask/helpers.py", line 354, in url_for
    force_external=external)
  File "/home/vagrant/kardboardve/lib/python2.6/site-packages/werkzeug/routing.py", line 1607, in build
    raise BuildError(endpoint, values, method)
BuildError: ('dashboard', {}, None)
```

Not finding url_for('dashboard').

Added HTML5 required attribute to search box to fix client side.
Added redirect to previous screen to fix server side.
Added redirect to root when search action is hit with no referrer.
